### PR TITLE
[PKG-3510] mahotas 1.4.13  :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 upload_channels:
   - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python
@@ -40,7 +39,10 @@ test:
   commands:
     - mahotas-features --help
     - pip check
-    - pytest -vvv --pyargs mahotas -k "not test_negative_values_haralick"  # [linux and aarch64]
+    # Seems like test_negative_values_haralick fails with the Segmentation Fault error on linux-aarch64,
+    # it's expected that you can run out of memory computing Haralick features on 16 bit images on some machines,
+    # see https://github.com/luispedro/mahotas/blob/v1.4.13/docs/source/faq.rst#i-ran-out-of-memory-computing-haralick-features-on-16-bit-images-is-it-not-supported 
+    - pytest -vv --pyargs mahotas -k "not test_negative_values_haralick"  # [linux and aarch64]
 
 about:
   home: https://mahotas.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   host:
     - python
     - pip
-    - numpy
+    - numpy {{ numpy }}
     - setuptools
     - wheel
   run:
@@ -40,6 +40,7 @@ test:
   commands:
     - mahotas-features --help
     - pip check
+    - pytest -v --pyargs mahotas
 
 about:
   home: https://mahotas.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     - mahotas-features --help
     - pip check
-    - pytest -vv --pyargs mahotas
+    - pytest -vvv
 
 about:
   home: https://mahotas.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     - mahotas-features --help
     - pip check
-    - pytest -vvv --pyargs mahotas
+    - pytest -vvv --pyargs mahotas -k "not test_negative_values_haralick"  # [linux and aarch64]
 
 about:
   home: https://mahotas.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,17 @@
 {% set name = "mahotas" %}
 {% set version = "1.4.13" %}
-{% set sha256 = "a78dfe15045a20a0d9e01538b80f874580cd3525ae3eaa2c83ced51eb455879c" %}
-
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: a78dfe15045a20a0d9e01538b80f874580cd3525ae3eaa2c83ced51eb455879c
 
 build:
-  number: 2
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - mahotas-features = mahotas.features_cli:main
 
@@ -26,33 +23,33 @@ requirements:
     - python
     - pip
     - numpy
+    - setuptools
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
 
 test:
+  imports:
+    - mahotas
   requires:
     - pytest
     - scipy
     - pillow
-
-  imports:
-    - mahotas
-
+    - pip
   commands:
     - mahotas-features --help
+    - pip check
 
 about:
   home: https://mahotas.readthedocs.io/
   license: MIT
   license_family: MIT
   license_file: COPYING
-
   summary: 'Mahotas: Computer Vision Library'
   description: |
     Mahotas is a library of fast computer vision algorithms
     (all implemented in C++) operating over numpy arrays.
-
   doc_url: https://mahotas.readthedocs.io/
   dev_url: https://github.com/luispedro/mahotas
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     - mahotas-features --help
     - pip check
-    - pytest -vvv
+    - pytest -vvv --pyargs mahotas
 
 about:
   home: https://mahotas.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     - mahotas-features --help
     - pip check
-    - pytest -v --pyargs mahotas
+    - pytest -vv --pyargs mahotas
 
 about:
   home: https://mahotas.readthedocs.io/

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-import sys
-
-import mahotas
-
-
-sys.exit(mahotas.test() is False)

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-
-
 import sys
 
 import mahotas


### PR DESCRIPTION
**Destination channel:** Snowflake

### Links

- [PKG-3510](https://anaconda.atlassian.net/browse/PKG-3510)
- release-notes: https://github.com/luispedro/mahotas/releases
- release-notes-tagged: https://github.com/explosion/thinc/releases/tag/v1.4.13
- changelog: https://github.com/luispedro/mahotas/blob/master/ChangeLog
- license: https://github.com/luispedro/mahotas/blob/master/COPYING
- requirements-tagged:
  - https://github.com/luispedro/mahotas/blob/v1.4.13/INSTALL
  - https://github.com/luispedro/mahotas/blob/v1.4.13/requirements.txt
  - https://github.com/luispedro/mahotas/blob/v1.4.13/setup.py
  - https://github.com/luispedro/mahotas/blob/v1.4.13/tests-requirements.txt


### Explanation of changes:

- Apply `anaconda-linter . --fix`: 
  - update `script`
  - add `wheel` and `setuptools` to `host`
  - add `pip check`
- Remove unused/redundant jinja variables
- Remove blank lines
- Reset the build/number
- Fix `numpy` in `host`
- Skip `test_negative_values_haralick` on `linux-aarch64 `because computing _Haralick_ is expected to fail on some platforms/machines, see https://github.com/luispedro/mahotas/blob/v1.4.13/docs/source/faq.rst#i-ran-out-of-memory-computing-haralick-features-on-16-bit-images-is-it-not-supported


[PKG-3510]: https://anaconda.atlassian.net/browse/PKG-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ